### PR TITLE
Improve soccer board PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Contains basic configuration to get you a site with:
 
 Replace sample content with your own and [configure as necessary](https://mmistakes.github.io/minimal-mistakes/docs/configuration/).
 
+This repository also hosts a soccer tactics board PWA under [`app/soccer-board`](app/soccer-board/). It lets you position players and a ball on a soccer field, edit player names and numbers, and share board states via encrypted URLs. The board works offline thanks to a service worker.
+
 ---
 
 ## Troubleshooting

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ date_format: "%Y-%m-%d"
 
 include:
   - _pages
+  - app
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/app/soccer-board/index.html
+++ b/app/soccer-board/index.html
@@ -1,0 +1,65 @@
+---
+layout: none
+---
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Soccer Board</title>
+<link rel="manifest" href="manifest.json">
+<style>
+html,body{height:100%;margin:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#222;color:#eee;display:flex;flex-direction:column;align-items:center}
+#board{flex:1;width:100%;display:flex;justify-content:center;align-items:center;position:relative}
+#field{position:relative;background:#060;aspect-ratio:105/68;width:100%;max-height:100%;border:4px solid #fff;box-sizing:border-box}
+#field svg{position:absolute;top:0;left:0;width:100%;height:100%}
+.token{position:absolute;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;touch-action:none}
+.player{width:40px;height:40px;border-radius:50%;color:#fff;font-weight:bold;display:flex;justify-content:center;align-items:center;font-size:14px}
+.player.red{background:#e44}
+.player.blue{background:#36f}
+.player.yellow{background:#fc3;color:#000}
+.player.green{background:#3b3}
+.player .name{font-size:10px;margin-top:2px;white-space:nowrap}
+#ball{font-size:24px}
+#controls{padding:10px;display:flex;gap:8px;flex-wrap:wrap}
+#controls input[type=text],#controls input[type=number]{width:80px}
+@media (orientation:landscape){
+  #field{height:100%;width:auto}
+}
+@media (orientation:portrait){
+  #field{width:100%;height:auto}
+}
+</style>
+</head>
+<body>
+<div id="board">
+  <div id="field">
+    <svg viewBox="0 0 105 68" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="105" height="68" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <line x1="52.5" y1="0" x2="52.5" y2="68" stroke="#fff" stroke-width="0.5"/>
+      <circle cx="52.5" cy="34" r="9.15" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <rect x="0" y="13.84" width="16.5" height="40.32" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <rect x="88.5" y="13.84" width="16.5" height="40.32" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <rect x="0" y="24.1" width="5.5" height="19.8" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <rect x="99.5" y="24.1" width="5.5" height="19.8" fill="none" stroke="#fff" stroke-width="0.5"/>
+      <circle cx="11" cy="34" r="0.5" fill="#fff"/>
+      <circle cx="94" cy="34" r="0.5" fill="#fff"/>
+    </svg>
+  </div>
+</div>
+
+<form id="controls">
+  <input id="name" type="text" placeholder="Name">
+  <input id="number" type="number" placeholder="No">
+  <select id="color">
+    <option value="red">Red</option>
+    <option value="blue">Blue</option>
+    <option value="yellow">Yellow</option>
+    <option value="green">Green</option>
+  </select>
+  <button type="submit">Add</button>
+</form>
+<script src="js/board.js"></script>
+</body>
+</html>

--- a/app/soccer-board/js/board.js
+++ b/app/soccer-board/js/board.js
@@ -1,0 +1,191 @@
+const PASSWORD = 'soccer-secret';
+let state = {players:[], ball:{x:50,y:50}};
+const field = document.getElementById('field');
+const form = document.getElementById('controls');
+const nameInput = document.getElementById('name');
+const numInput = document.getElementById('number');
+const colorInput = document.getElementById('color');
+let editId = null;
+let dragTarget = null, offsetX=0, offsetY=0;
+
+function defaultPlayers(){
+  const base=[
+    {num:1,x:5,y:50},
+    {num:2,x:20,y:15},
+    {num:3,x:20,y:35},
+    {num:4,x:20,y:65},
+    {num:5,x:20,y:85},
+    {num:6,x:40,y:25},
+    {num:7,x:40,y:45},
+    {num:8,x:40,y:55},
+    {num:9,x:40,y:75},
+    {num:10,x:60,y:35},
+    {num:11,x:60,y:65}
+  ];
+  const red=base.map((p,i)=>({...p,color:'red',id:'r'+(i+1)}));
+  const blue=base.map((p,i)=>({num:p.num,x:100-p.x,y:p.y,color:'blue',id:'b'+(i+1)}));
+  return red.concat(blue);
+}
+
+function editPlayer(id){
+  const p=state.players.find(pl=>pl.id==id);
+  if(!p)return;
+  editId=id;
+  nameInput.value=p.name||'';
+  numInput.value=p.num;
+  colorInput.value=p.color;
+  nameInput.focus();
+}
+
+function createPlayer(p){
+  const el=document.createElement('div');
+  el.className='token player '+p.color;
+  el.style.left=p.x+'%';
+  el.style.top=p.y+'%';
+  el.dataset.id=p.id;
+  const num=document.createElement('div');
+  num.textContent=p.num;
+  el.appendChild(num);
+  if(p.name){
+    const n=document.createElement('div');
+    n.className='name';
+    n.textContent=p.name;
+    el.appendChild(n);
+  }
+  el.addEventListener('pointerdown',startDrag);
+  el.addEventListener('click',()=>editPlayer(p.id));
+  el.addEventListener('dblclick',()=>removePlayer(p.id));
+  field.appendChild(el);
+}
+
+function createBall(){
+  const b=document.createElement('div');
+  b.id='ball';
+  b.className='token';
+  b.textContent='\u26BD';
+  b.style.left=state.ball.x+'%';
+  b.style.top=state.ball.y+'%';
+  b.addEventListener('pointerdown',startDrag);
+  field.appendChild(b);
+}
+
+function startDrag(e){
+  dragTarget=e.target; dragTarget.setPointerCapture(e.pointerId);
+  const rect=field.getBoundingClientRect();
+  offsetX=(e.clientX-rect.left)/(rect.width)*100 - parseFloat(dragTarget.style.left);
+  offsetY=(e.clientY-rect.top)/(rect.height)*100 - parseFloat(dragTarget.style.top);
+  dragTarget.addEventListener('pointermove',onMove);
+  dragTarget.addEventListener('pointerup',endDrag);
+}
+function onMove(e){
+  const rect=field.getBoundingClientRect();
+  const x=(e.clientX-rect.left)/(rect.width)*100 - offsetX;
+  const y=(e.clientY-rect.top)/(rect.height)*100 - offsetY;
+  dragTarget.style.left=Math.min(100,Math.max(0,x))+'%';
+  dragTarget.style.top=Math.min(100,Math.max(0,y))+'%';
+}
+function endDrag(e){
+  dragTarget.removeEventListener('pointermove',onMove);
+  dragTarget.removeEventListener('pointerup',endDrag);
+  const id=dragTarget.dataset.id;
+  if(id){
+    const p=state.players.find(pl=>pl.id==id);
+    p.x=parseFloat(dragTarget.style.left);
+    p.y=parseFloat(dragTarget.style.top);
+  }else{
+    state.ball.x=parseFloat(dragTarget.style.left);
+    state.ball.y=parseFloat(dragTarget.style.top);
+  }
+  saveState();
+  dragTarget=null;
+}
+
+function removePlayer(id){
+  const idx=state.players.findIndex(p=>p.id==id);
+  if(idx>=0){state.players.splice(idx,1);}
+  const el=document.querySelector('.player[data-id="'+id+'"]');
+  if(el) el.remove();
+  saveState();
+}
+
+form.addEventListener('submit',e=>{
+  e.preventDefault();
+  if(editId){
+    const p=state.players.find(pl=>pl.id==editId);
+    if(p){
+      p.name=nameInput.value;
+      p.num=numInput.value;
+      p.color=colorInput.value;
+      const el=document.querySelector('.player[data-id="'+editId+'"]');
+      if(el){
+        el.className='token player '+p.color;
+        el.firstChild.textContent=p.num;
+        let n=el.querySelector('.name');
+        if(p.name){
+          if(!n){n=document.createElement('div');n.className='name';el.appendChild(n);} 
+          n.textContent=p.name;
+        }else if(n){
+          n.remove();
+        }
+      }
+    }
+    editId=null;
+  }else{
+    const p={id:Date.now().toString(),name:nameInput.value,num:numInput.value,color:colorInput.value,x:50,y:50};
+    state.players.push(p);
+    createPlayer(p);
+  }
+  form.reset();
+  saveState();
+});
+
+async function saveState(){
+  const json=JSON.stringify(state);
+  const enc=await encryptData(PASSWORD,json);
+  history.replaceState(null,'','?d='+encodeURIComponent(enc));
+}
+
+async function loadState(){
+  const params=new URLSearchParams(location.search);
+  if(params.has('d')){
+    try{
+      const data=await decryptData(PASSWORD,params.get('d'));
+      state=JSON.parse(data);
+    }catch(e){console.error(e);}
+  }else{
+    state.players=defaultPlayers();
+  }
+  state.players.forEach(createPlayer);
+  createBall();
+  if(!params.has('d')) saveState();
+}
+
+// encryption helpers using Web Crypto
+async function getKey(password,salt){
+  const enc=new TextEncoder();
+  const mat=await crypto.subtle.importKey('raw',enc.encode(password),'PBKDF2',false,['deriveKey']);
+  return crypto.subtle.deriveKey({name:'PBKDF2',salt,iterations:100000,hash:'SHA-256'},mat,{name:'AES-GCM',length:256},false,['encrypt','decrypt']);
+}
+async function encryptData(password,data){
+  const enc=new TextEncoder();
+  const salt=crypto.getRandomValues(new Uint8Array(16));
+  const iv=crypto.getRandomValues(new Uint8Array(12));
+  const key=await getKey(password,salt);
+  const cipher=await crypto.subtle.encrypt({name:'AES-GCM',iv},key,enc.encode(data));
+  const buf=new Uint8Array(salt.length+iv.length+cipher.byteLength);
+  buf.set(salt,0); buf.set(iv,salt.length); buf.set(new Uint8Array(cipher),salt.length+iv.length);
+  return btoa(String.fromCharCode(...buf));
+}
+async function decryptData(password,str){
+  const data=Uint8Array.from(atob(str),c=>c.charCodeAt(0));
+  const salt=data.slice(0,16); const iv=data.slice(16,28); const cipher=data.slice(28);
+  const key=await getKey(password,salt);
+  const plain=await crypto.subtle.decrypt({name:'AES-GCM',iv},key,cipher);
+  return new TextDecoder().decode(plain);
+}
+
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('service-worker.js');
+}
+
+loadState();

--- a/app/soccer-board/manifest.json
+++ b/app/soccer-board/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Soccer Board",
+  "short_name": "Board",
+  "display": "standalone",
+  "start_url": ".",
+  "background_color": "#0a5",
+  "theme_color": "#0a5",
+  "icons": []
+}

--- a/app/soccer-board/service-worker.js
+++ b/app/soccer-board/service-worker.js
@@ -1,0 +1,6 @@
+self.addEventListener('install',e=>{
+  e.waitUntil(caches.open('board-v1').then(c=>c.addAll(['./','./index.html','./js/board.js','./manifest.json','./service-worker.js'])));
+});
+self.addEventListener('fetch',e=>{
+  e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)));
+});


### PR DESCRIPTION
## Summary
- redesign soccer board with modern responsive layout
- draw soccer field lines with SVG
- add edit player form and default 11v11 setup
- cache service worker itself
- document the soccer board PWA in README

## Testing
- ❌ `bundle exec jekyll build` (failed: `jekyll` not installed)


------
https://chatgpt.com/codex/tasks/task_e_6853e455ccb88331ad6d334c0f75f33f