### PR TITLE
Fix mobile double tap and update soccer board UI

### DIFF
--- a/app/soccer-board/index.html
+++ b/app/soccer-board/index.html
@@ -37,21 +37,24 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 #modal #save-btn:hover{background:#45a049;box-shadow:0 4px 8px rgba(76, 175, 80, 0.3)}
 #modal #cancel-btn{background:#555;color:white;}
 #modal #cancel-btn:hover{background:#666;box-shadow:0 4px 8px rgba(0, 0, 0, 0.2)}
-#modal #delete-btn{background:#f44336;color:white;}
+  #modal #delete-btn{background:#f44336;color:white;}
   #modal #delete-btn:hover{background:#d32f2f;box-shadow:0 4px 8px rgba(244, 67, 54, 0.3)}
   #toolbar{display:flex;flex-wrap:wrap;gap:8px;justify-content:center;margin:8px}
-  #toolbar button{padding:8px 12px;border:none;border-radius:6px;font-size:14px;font-weight:bold;cursor:pointer}
-  #toolbar .group{display:flex;gap:8px}
-  #help-modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);display:flex;justify-content:center;align-items:center}
-  #help-modal.hidden{display:none}
-  #help-modal .box{background:#333;padding:24px;border-radius:12px;max-width:300px;color:#fff;box-shadow:0 8px 24px rgba(0,0,0,0.4);line-height:1.4}
-  #help-modal button{margin-top:12px;padding:8px 12px;border:none;border-radius:6px;background:#555;color:#fff;font-weight:bold;cursor:pointer}
-@media (orientation:landscape){
-  #field{height:100%;width:auto}
-}
-@media (orientation:portrait){
-  #field{width:100%;height:auto}
-}
+  #toolbar button{padding:10px 16px;border:none;border-radius:8px;font-size:14px;font-weight:bold;cursor:pointer;background:#4a90e2;color:#fff;box-shadow:0 2px 4px rgba(0,0,0,0.3);transition:background 0.2s,transform 0.2s}
+  #toolbar button:hover{background:#3977c8;transform:translateY(-2px)}
+  #help-modal,#share-modal,#preset-modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);display:flex;justify-content:center;align-items:center;backdrop-filter:blur(3px)}
+  #help-modal.hidden,#share-modal.hidden,#preset-modal.hidden{display:none}
+  #help-modal .box,#share-modal .box,#preset-modal .box{background:#333;padding:24px;border-radius:12px;max-width:300px;color:#fff;box-shadow:0 8px 24px rgba(0,0,0,0.4);line-height:1.4;display:flex;flex-direction:column;gap:12px}
+  #help-modal button,#share-modal button,#preset-modal button{padding:8px 12px;border:none;border-radius:6px;background:#555;color:#fff;font-weight:bold;cursor:pointer}
+  @media (orientation:landscape){
+    #field{height:100%;width:auto}
+  }
+  @media (orientation:portrait){
+    #field{width:100%;height:auto}
+  }
+  @media (max-width:600px){
+    #modal .box{align-self:flex-start;margin-top:20px}
+  }
 </style>
 </head>
 <body>
@@ -72,17 +75,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 </div>
 
 <div id="toolbar">
-  <div class="group" id="share-options">
-    <button id="share-line">LINE</button>
-    <button id="share-x">X</button>
-    <button id="share-copy">Copy URL</button>
-  </div>
-  <div class="group" id="preset-options">
-    <button data-preset="clear">Clear</button>
-    <button data-preset="red11">Red11</button>
-    <button data-preset="red8">Red8</button>
-    <button data-preset="full">Red&Blue</button>
-  </div>
+  <button id="share-btn">Share</button>
+  <button id="preset-btn">Preset</button>
   <button id="help-btn">Help</button>
 </div>
 
@@ -105,9 +99,27 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   </div>
 </div>
 
+<div id="share-modal" class="hidden">
+  <div class="box">
+    <button id="share-native">Share</button>
+    <button id="share-copy">Copy URL</button>
+    <button id="share-close">Close</button>
+  </div>
+</div>
+
+<div id="preset-modal" class="hidden">
+  <div class="box">
+    <button data-preset="clear">Clear</button>
+    <button data-preset="red11">Red11</button>
+    <button data-preset="red8">Red8</button>
+    <button data-preset="full">Red&Blue</button>
+    <button id="preset-close">Close</button>
+  </div>
+</div>
+
 <div id="help-modal" class="hidden">
   <div class="box">
-    <p>トークンをドラッグして移動します。PCではダブルクリック、スマホではダブルタップまたは長押しで編集できます。フィールドの空き部分をダブルクリック/ダブルタップすると新規追加できます。</p>
+    <p>It is a soccer tactics board. Double click to edit or add new tokens. Tokens can be dragged. You can share via URL.</p>
     <button id="help-close">Close</button>
   </div>
 </div>

--- a/app/soccer-board/js/board.js
+++ b/app/soccer-board/js/board.js
@@ -12,13 +12,19 @@ let editId = null;
 let newPos = null;
 let dragTarget = null, offsetX=0, offsetY=0;
 let pointerMoved = false, pressStart = 0, lastTap = 0;
-const shareLineBtn = document.getElementById('share-line');
-const shareXBtn = document.getElementById('share-x');
-const shareCopyBtn = document.getElementById('share-copy');
-const presetBtns = document.querySelectorAll('#preset-options button');
+let fieldLastTap = 0;
+const shareBtn = document.getElementById('share-btn');
+const presetBtn = document.getElementById('preset-btn');
 const helpBtn = document.getElementById('help-btn');
+const shareModal = document.getElementById('share-modal');
+const presetModal = document.getElementById('preset-modal');
 const helpModal = document.getElementById('help-modal');
+const shareNativeBtn = document.getElementById('share-native');
+const shareCopyBtn = document.getElementById('share-copy');
+const shareCloseBtn = document.getElementById('share-close');
+const presetCloseBtn = document.getElementById('preset-close');
 const helpClose = document.getElementById('help-close');
+const presetBtns = document.querySelectorAll('#preset-modal button[data-preset]');
 
 function defaultPlayers(){
   const red=[
@@ -120,6 +126,21 @@ field.addEventListener('dblclick',e=>{
   const x=(e.clientX-rect.left)/rect.width*100;
   const y=(e.clientY-rect.top)/rect.height*100;
   openNew(x,y);
+});
+
+field.addEventListener('pointerup',e=>{
+  if(e.pointerType!=='touch') return;
+  if(e.target.closest('.token')) return;
+  const rect=field.getBoundingClientRect();
+  const now=Date.now();
+  if(now-fieldLastTap<300){
+    const x=(e.clientX-rect.left)/rect.width*100;
+    const y=(e.clientY-rect.top)/rect.height*100;
+    openNew(x,y);
+    fieldLastTap=0;
+  }else{
+    fieldLastTap=now;
+  }
 });
 
 // タッチデバイスのためのスクロール防止（フィールド内でのスクロールを防止）
@@ -365,23 +386,27 @@ if('serviceWorker' in navigator) {
 
 // ブラウザキャッシュをクリア
 caches.keys().then(keyList => {
-  return Promise.all(keyList.map(key => {
-    return caches.delete(key);
-  }));
+  return Promise.all(keyList.map(key => caches.delete(key)));
 }).catch(e => console.warn('Cache clear error:', e));
 
-shareLineBtn.addEventListener('click',()=>{
+shareBtn.addEventListener('click',()=>shareModal.classList.remove('hidden'));
+shareCloseBtn.addEventListener('click',()=>shareModal.classList.add('hidden'));
+shareNativeBtn.addEventListener('click',()=>{
   const url=location.href;
-  window.open('https://social-plugins.line.me/lineit/share?url='+encodeURIComponent(url),'_blank');
-});
-shareXBtn.addEventListener('click',()=>{
-  const url=location.href;
-  window.open('https://twitter.com/intent/tweet?url='+encodeURIComponent(url),'_blank');
+  if(navigator.share){
+    navigator.share({title:'Soccer Board',url}).catch(()=>{});
+  }else{
+    navigator.clipboard.writeText(url).then(()=>alert('Copied')).catch(()=>alert('Failed'));
+  }
 });
 shareCopyBtn.addEventListener('click',async ()=>{
   try{await navigator.clipboard.writeText(location.href);alert('Copied');}catch(e){alert('Failed');}
 });
-presetBtns.forEach(btn=>btn.addEventListener('click',()=>applyPreset(btn.dataset.preset)));
+
+presetBtn.addEventListener('click',()=>presetModal.classList.remove('hidden'));
+presetCloseBtn.addEventListener('click',()=>presetModal.classList.add('hidden'));
+presetBtns.forEach(btn=>btn.addEventListener('click',()=>{applyPreset(btn.dataset.preset);presetModal.classList.add('hidden');}));
+
 helpBtn.addEventListener('click',()=>helpModal.classList.remove('hidden'));
 helpClose.addEventListener('click',()=>helpModal.classList.add('hidden'));
 


### PR DESCRIPTION
## Summary
- restyle toolbar buttons with a modern look
- reorganize toolbar into Share, Preset and Help buttons
- add Share and Preset modals
- improve help message
- add mobile-friendly modal position
- add touch double-tap support for iPhone Safari
- use Web Share API fallback for sharing

## Testing
- `bundle exec jekyll build` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685aab87712483318c3dcd102776553d